### PR TITLE
Avoid adding the BRANCHOUT_HOME property to the Branchoutfile:

### DIFF
--- a/bats/branchout.bats
+++ b/bats/branchout.bats
@@ -74,7 +74,7 @@ load helper
   assert_success_file all/frog-aleph
 }
 
-@test "branchout add" {
+@test "branchout init add to new branchout" {
   mkdir -p target/tests/add
   cd target/tests/add
   HOME=${BUILD_DIRECTORY}
@@ -90,6 +90,20 @@ gitty"
   assert_success_file status/no-clone
   run branchout add frog-beta
   assert_success_file_sort status/two-no-clone
+}
+
+@test "branchout init only sets url and name" {
+  mkdir -p target/tests/init-branchoutfile
+  cd target/tests/init-branchoutfile
+  HOME=${BUILD_DIRECTORY}
+  git init
+  run branchout-init <<< "brname
+gitty"
+  assert_success
+  run branchout status
+  assert_error "No projects to show, try branchout add <project-name>"
+  assert_equal "BRANCHOUT_NAME=brname
+BRANCHOUT_GIT_BASEURL=gitty" "$(cat Branchoutfile)"
 }
 
 @test "branchout add no params should error" {

--- a/branchout-init
+++ b/branchout-init
@@ -24,8 +24,10 @@ function branchout_init_name() {
   DEFAULT_BRANCHOUT_NAME="$(basename "${PWD}")"
   printf "Enter branchout name [%s]: " "${DEFAULT_BRANCHOUT_NAME}"
   read -r BRANCHOUT_NAME
-  test -z "${BRANCHOUT_NAME}" && BRANCHOUT_NAME="$(basename "${PWD}")" && echo
-  echo "BRANCHOUT_HOME=\"${HOME}/branchout/${BRANCHOUT_NAME}\"" >> ${BRANCHOUT_FILE}
+  if test -z "${BRANCHOUT_NAME}"; then
+     BRANCHOUT_NAME="${DEFAULT_BRANCHOUT_NAME}"
+     echo
+  fi
 }
 
 function branchout_init_baseurl()  {


### PR DESCRIPTION
the home is related to the user and not the branchout project itself so it should never be stored, for some reason init was adding it.