### PR TITLE
Yarnrc quoted

### DIFF
--- a/.deploy-to-homebrew
+++ b/.deploy-to-homebrew
@@ -29,6 +29,7 @@ echo "class Branchout < Formula
 
   depends_on \"branchout/branchout/branchout-core\"
   depends_on \"branchout/branchout/branchout-maven\"
+  depends_on \"branchout/branchout/branchout-yarn\"
   
   def test
     system \"#{bin}/branchout version\"

--- a/.deploy-to-homebrew
+++ b/.deploy-to-homebrew
@@ -70,7 +70,7 @@ echo "class BranchoutMaven < Formula
   sha256 \"${HASH}\"
   version \"${VERSION:1}\"
 
-  depends_on \"branchout/branchout/core\"
+  depends_on \"branchout/branchout/branchout-core\"
   depends_on \"maven\"
   
   def install
@@ -91,7 +91,7 @@ echo "class BranchoutYarn < Formula
   sha256 \"${HASH}\"
   version \"${VERSION:1}\"
 
-  depends_on \"branchout/branchout/core\"
+  depends_on \"branchout/branchout/branchout-core\"
   depends_on \"yarn\"
   
   def install

--- a/branchout-yarn
+++ b/branchout-yarn
@@ -29,10 +29,10 @@ function yarnSettings() {
         echo "using yarnrc template ${BRANCHOUT_DIRECTORY}/branchout-templates/yarnrc"
         echo <(cat "${BRANCHOUT_DIRECTORY}/branchout-templates/yarnrc") > "${BRANCHOUT_HOME}/node/yarnrc"
     else
-        echo "registry ${BRANCHOUT_NPM_REGISTRY}
+        echo "registry \"${BRANCHOUT_NPM_REGISTRY}\"
+user \"${BRANCHOUT_CONFIG_NPM_USER}\"
+email \"${BRANCHOUT_CONFIG_GIT_EMAIL}\"
 always-auth true
-user ${BRANCHOUT_CONFIG_NPM_USER}
-email ${BRANCHOUT_CONFIG_GIT_EMAIL}
 disable-self-update-check true
 " > "${BRANCHOUT_HOME}/node/yarnrc"
     fi
@@ -82,7 +82,7 @@ function main() {
       yarnSettings "${*}"
       ;;
     show)
-      grep -v auth "${BRANCHOUT_HOME}/node/yarnrc"
+      grep -v '^auth ' "${BRANCHOUT_HOME}/node/yarnrc"
       ;;
     *)
       test -f "${BRANCHOUT_HOME}/node/.npmrc" || yarnSettings

--- a/output/yarn/yarnrc.txt
+++ b/output/yarn/yarnrc.txt
@@ -1,4 +1,5 @@
-registry https://yarn.example.org/repository/npm-example
-user npmuser
-email stickycode@example.org
+registry "https://yarn.example.org/repository/npm-example"
+user "npmuser"
+email "stickycode@example.org"
+always-auth true
 disable-self-update-check true


### PR DESCRIPTION
Some properties in the yarnrc must be quoted or yarn just ignores the whole file, which is very annoying