### PR TITLE
Ensure in configuration

### DIFF
--- a/bats/branchout-yarn.bats
+++ b/bats/branchout-yarn.bats
@@ -59,7 +59,7 @@ writing npm config to ../branchout/yarn-settings-twice/node/.npmrc"
 
 @test "branchout yarn - use existing settings" {
   example yarn-use-existing-settings
-  run branchout set BRANCHOUT_NPM_REGISTRY "https://yarn.example.org/repository/npm-example"
+  run branchout set NPM_REGISTRY "https://yarn.example.org/repository/npm-example"
   assert_success
   run branchout set-config NPM_USER npmuser
   assert_success

--- a/branchout
+++ b/branchout
@@ -4,36 +4,35 @@ test -n "${DEBUG}" && set -x
 set -e
 
 function branchout_get-config() {
-  if test -f "${BRANCHOUT_STATE}/branchoutrc"; then
-    grep "^BRANCHOUT_CONFIG_${1}=" "${BRANCHOUT_STATE}/branchoutrc" | sed -e 's,^.*="\(.*\)"$,\1,'
-  fi
+  getConfigValue "${1}"
 }
 
 function branchout_set-config() {
-  test -z "${2}" && usage "You must supply a value to set"
-  test -f "${BRANCHOUT_STATE}/branchoutrc" && grep -v "^BRANCHOUT_CONFIG_${1}=" "${BRANCHOUT_STATE}/branchoutrc" > "${BRANCHOUT_STATE}/branchoutrc.tmp" && true
-  echo "BRANCHOUT_CONFIG_${1}=\"${2}\"" >> "${BRANCHOUT_STATE}/branchoutrc.tmp"
-  sort "${BRANCHOUT_STATE}/branchoutrc.tmp" > "${BRANCHOUT_STATE}/branchoutrc"
-  rm "${BRANCHOUT_STATE}/branchoutrc.tmp"
+  setConfigValue "${1}" "${2}"
 }
 
-function branchout_ensure_config() {
-  ensureConfigValue "${1}" "${1}"
+function branchout_ensure-config() {
+  if test $# -eq 2; then
+    ensureConfigValue "${1}" "${1}" "${2}"
+  else
+    ensureConfigValue "${1}" "${1}"
+  fi
 }
 
 function branchout_ensure() {
-  ensureValue "${1}" "${1}"
+  if test $# -eq 2; then
+    ensureValue "${1}" "${1}" "${2}"
+  else
+    ensureValue "${1}" "${1}"
+  fi
 }
 
 function branchout_get() {
-  grep "^${1}=" "${PROJECTION_DIRECTORY}/${BRANCHOUT_FILE}" | sed -e 's,^.*="\(.*\)"$,\1,'
+  getValue "${1}"
 }
 
 function branchout_set() {
-  grep -v "^${1}=" "${PROJECTION_DIRECTORY}/${BRANCHOUT_FILE}" > "${PROJECTION_DIRECTORY}/${BRANCHOUT_FILE}".tmp && true
-  echo "${1}=\"${2}\"" >> "${PROJECTION_DIRECTORY}/${BRANCHOUT_FILE}.tmp"
-  sort "${PROJECTION_DIRECTORY}/${BRANCHOUT_FILE}.tmp" > "${PROJECTION_DIRECTORY}/${BRANCHOUT_FILE}"
-  rm "${PROJECTION_DIRECTORY}/${BRANCHOUT_FILE}.tmp"
+  setValue "${1}" "${2}"
 }
 
 function branchout_status() {
@@ -102,7 +101,9 @@ function usage() {
 }
 
 function execute() {
-  if declare -f -F branchout_"${branchoutModule}" >/dev/null; then
+  if declare -f -F "branchout_${branchoutModule}" >/dev/null; then
+    # shellcheck source=branchout-configuration
+    . "${BRANCHOUT_PATH}/branchout-configuration"
     # shellcheck source=branchout-environment
     . "${BRANCHOUT_PATH}/branchout-environment"
     eval branchout_"${branchoutModule}" "${@}"
@@ -123,9 +124,6 @@ function main() {
   fi
 
   BRANCHOUT_PATH="$(dirname "$0")"
-
-  # shellcheck source=branchout-configuration
-  . "${BRANCHOUT_PATH}/branchout-configuration"
 
   case "${1}" in
     help)

--- a/branchout-configuration
+++ b/branchout-configuration
@@ -3,6 +3,78 @@
 test -n "${DEBUG}" && set -x
 set -e
 
+function fail() {
+  test -n "${1}" && echo "${1}" && echo
+  exit 2
+}
+
+function getConfigValue() {
+  test -z "${BRANCHOUT_STATE}" && fail "BRANCHOUT_STATE is not defined"
+  if test -f "${BRANCHOUT_STATE}/branchoutrc"; then
+    grep "^BRANCHOUT_CONFIG_${1}=" "${BRANCHOUT_STATE}/branchoutrc" | sed -e 's,^.*="\(.*\)"$,\1,'
+  fi
+}
+
+function setConfigValue() {
+  test -z "${BRANCHOUT_STATE}" && fail "BRANCHOUT_STATE is not defined"
+  test -z "${2}" && usage "You must supply a value to set"
+  test -f "${BRANCHOUT_STATE}/branchoutrc" && grep -v "^BRANCHOUT_CONFIG_${1}=" "${BRANCHOUT_STATE}/branchoutrc" > "${BRANCHOUT_STATE}/branchoutrc.tmp" && true
+  echo "BRANCHOUT_CONFIG_${1}=\"${2}\"" >> "${BRANCHOUT_STATE}/branchoutrc.tmp"
+  sort "${BRANCHOUT_STATE}/branchoutrc.tmp" > "${BRANCHOUT_STATE}/branchoutrc"
+  rm "${BRANCHOUT_STATE}/branchoutrc.tmp"
+}
+
+function getValue() {
+  test -z "${BRANCHOUT_STATE}" && fail "BRANCHOUT_STATE is not defined"
+  grep "^BRANCHOUT_${1}=" "${PROJECTION_DIRECTORY}/${BRANCHOUT_FILE}" | sed -e 's,^.*="\(.*\)"$,\1,'
+}
+
+function setValue() {
+  test -z "${PROJECTION_DIRECTORY}" && fail "PROJECTION_DIRECTORY is not defined"
+  grep -v "^BRANCHOUT_${1}=" "${PROJECTION_DIRECTORY}/${BRANCHOUT_FILE}" > "${PROJECTION_DIRECTORY}/${BRANCHOUT_FILE}".tmp && true
+  echo "BRANCHOUT_${1}=\"${2}\"" >> "${PROJECTION_DIRECTORY}/${BRANCHOUT_FILE}.tmp"
+  sort "${PROJECTION_DIRECTORY}/${BRANCHOUT_FILE}.tmp" > "${PROJECTION_DIRECTORY}/${BRANCHOUT_FILE}"
+  rm "${PROJECTION_DIRECTORY}/${BRANCHOUT_FILE}.tmp"
+}
+
+function readValue() {
+  if test -z "${3}"; then
+    printf "Please provide %s: " "${1}"
+  else
+    printf "Please provide %s [%s]: " "${1}" "${3}"
+  fi
+  # if the user does not enter a value sure to add a newline before the error message if there is no default
+  read -r VALUE || true
+  echo
+  test -z "${VALUE}" && VALUE="${3}"
+  test -z "${VALUE}" && fail "Error: You must supply a value for $1"
+  export "${2}=${VALUE}"
+}
+
+function readSecret() {
+  printf "Please provide %s: " "${1}"
+  read -s -r VALUE
+  echo
+  test -z "${VALUE}" && fail "Error: You must supply a value for $1"
+  export "${2}=${VALUE}"
+}
+
+function ensureValue() {
+  valueName="BRANCHOUT_${2}"
+  if test -z "${!valueName}"; then
+    readValue "${1}" "${valueName}" "${3}"
+    setValue "${2}" "${!valueName}"
+  fi
+}
+
+function ensureConfigValue() {
+  configName="BRANCHOUT_CONFIG_${2}"
+  if test -z "${!configName}"; then
+    readValue "${1}" "${configName}" "${3}"
+    setConfigValue "${2}" "${!configName}"
+  fi
+}
+
 export BO_THEME_RESET="\\033[0m"
 export BO_THEME_OK="\\033[0m"
 export BO_THEME_NOTICE="\\033[35m"

--- a/branchout-environment
+++ b/branchout-environment
@@ -3,43 +3,6 @@
 test -n "${DEBUG}" && set -x
 set -e
 
-function fail() {
-  test -n "${1}" && echo "${1}" && echo
-  exit 2
-}
-
-function readValue() {
-  printf "Please provide %s: " "${1}"
-  read -r VALUE
-  echo
-  test -z "${VALUE}" && fail "Error: You must supply a value for $1"
-  export "${2}=${VALUE}"
-}
-
-function readSecret() {
-  printf "Please provide %s: " "${1}"
-  read -s -r VALUE
-  echo
-  test -z "${VALUE}" && fail "Error: You must supply a value for $1"
-  export "${2}=${VALUE}"
-}
-
-ensureValue() {
-  configName="BRANCHOUT_${2}"
-  if test -z "${!configName}"; then
-    readValue "${1}" "${configName}"
-    "${BRANCHOUT_PATH}/branchout" set "${configName}" "${!configName}"
-  fi
-}
-
-ensureConfigValue() {
-  configName="BRANCHOUT_CONFIG_${2}"
-  if test -z "${!configName}"; then
-    readValue "${1}" "${configName}"
-    "${BRANCHOUT_PATH}/branchout" set-config "${2}" "${!configName}"
-  fi
-}
-
 # Check if the give directory contains the branchout files
 function branchoutFiles() {
   if test -f "${1}/Branchoutfile"; then
@@ -65,13 +28,11 @@ function branchoutDirectory() {
     fi
     PROJECTION_DIRECTORY=$(dirname "${PROJECTION_DIRECTORY}")
   done
-  usage "Branchoutfile configuration not found in parent hierarchy, run branchout init"
+  fail "Branchoutfile configuration not found in parent hierarchy, perhaps you need to be in a project directory $(ls -d "${HOME}/${BRANCHOUT_PROJECTS_DIRECTORY}" )"
 }
 
-function usage() {
+function fail() {
   test -n "${1}" && echo "${1}" && echo
-  echo "branchout-environment: load the environment
-"
   exit 1
 }
 
@@ -87,7 +48,7 @@ export BRANCHOUT_FILE
 # shellcheck source=examples/Branchoutfile
 source "${PROJECTION_DIRECTORY}/${BRANCHOUT_FILE}"
 
-test -z "${BRANCHOUT_NAME}" && usage "Branchout name not defined in ${BRANCHOUT_FILE}, run branchout init"
+test -z "${BRANCHOUT_NAME}" && fail "Branchout name not defined in ${BRANCHOUT_FILE}, run branchout init"
 export BRANCHOUT_NAME
 BRANCHOUT_STATE="${HOME}/branchout/${BRANCHOUT_NAME}"
 export BRANCHOUT_STATE

--- a/branchout-yarn
+++ b/branchout-yarn
@@ -18,7 +18,7 @@ function yarnSettings() {
     ensureValue "your npm registry" "NPM_REGISTRY"
     if [[ ${BRANCHOUT_NPM_REGISTRY} =~ ^http:// ]]; then
       export BRANCHOUT_NPM_REGISTRY="https:${BRANCHOUT_NPM_REGISTRY#*:}"
-      "${BRANCHOUT_PATH}/branchout" set "NPM_REGISTRY" "https${BRANCHOUT_NPM_REGISTRY}"
+      setValue "NPM_REGISTRY" "https${BRANCHOUT_NPM_REGISTRY}"
     fi
     
     ensureConfigValue "npm registry username" "NPM_USER"


### PR DESCRIPTION
Move all the value and config functions into branchout-configuration to make it easier to import them and reuse them, branchout-environment is overloaded with meaning

More testing coverage to prove they are correct

Add default value support so that you can ensure a value and use the default if they user accepts it