### PR TITLE
Allow the init protocol to be used for git operations - Issue 54

### DIFF
--- a/bats/branchout-environment.bats
+++ b/bats/branchout-environment.bats
@@ -9,17 +9,10 @@ load helper
 @test "branchout environment configuration missing BRANCHOUT_NAME fails" {
   mkdir -p target/missing-name
   cd target/missing-name
+  HOME=..
   touch Branchoutfile
   run branchout status
   assert_error "Branchout name not defined in Branchoutfile, run branchout init" 
-}
-
-@test "branchout environment configuration missing BRANCHOUT_GIT_BASEURL fails" {
-  mkdir -p target/missing-giturl target/branchout/missing-giturl 
-  cd target/missing-giturl
-  echo 'BRANCHOUT_NAME="missing-giturl"' > Branchoutfile 
-  run branchout status
-  assert_error "Git base url is not defined in Branchoutfile, run branchout init" 
 }
 
 @test "branchout environment home is missing fails" {

--- a/bats/branchout-init.bats
+++ b/bats/branchout-init.bats
@@ -1,134 +1,335 @@
 load helper
 
-@test "branchout init is shellcheck compliant with no exceptions" {
+@test "branchout init - is shellcheck compliant with no exceptions" {
   run shellcheck -x branchout-init
   assert_success
 }
 
-@test "branchout init from url" {
+@test "branchout init - from url, no email errors" {
   HOME=${BUILD_DIRECTORY}
-  run branchout init file://${BUILD_DIRECTORY}/repositories/base
-  assert_success "Cloning into 'base'...
-BRANCHOUT_GIT_BASEURL=file://${BUILD_DIRECTORY}/repositories"
-  cd target/projects/base
-  run branchout status
-  assert_success_file_sort init/from-url
+  run branchout init file://${BUILD_DIRECTORY}/repositories/base base-noemail <<< ""
+  assert_failure "Branchout projected 'file://${BUILD_DIRECTORY}/repositories/base' into ${BUILD_DIRECTORY}/projects/base-noemail
+Branchout state will be stored in ${BUILD_DIRECTORY}/branchout/base
+Please provide your git author email: 
+Error: You must supply a value for your git author email"
 }
 
-@test "branchout init from url.git" {
+@test "branchout init - from url using supplied branchout and supplied author email" {
   HOME=${BUILD_DIRECTORY}
-  run branchout init file://${BUILD_DIRECTORY}/repositories/ghbase.git
-  assert_success "Cloning into 'ghbase'...
-BRANCHOUT_GIT_BASEURL=file://${BUILD_DIRECTORY}/repositories"
-  cd target/projects/ghbase
+  run branchout init file://${BUILD_DIRECTORY}/repositories/empty rename-projection <<< "alternate-branchout-name
+stickycode@example.com"
+  assert_success "Branchout projected 'file://${BUILD_DIRECTORY}/repositories/empty' into ${BUILD_DIRECTORY}/projects/rename-projection
+Please provide branchout name [empty]: 
+Branchout state will be stored in ${BUILD_DIRECTORY}/branchout/alternate-branchout-name
+Please provide your git author email: 
+Set the git author to stickycode@example.com"
+}
+
+@test "branchout init - from url using default branchout and supplied author email" {
+  HOME=${BUILD_DIRECTORY}
+  run branchout init file://${BUILD_DIRECTORY}/repositories/empty <<< "
+stickycode@example.com"
+  assert_success "Branchout projected 'file://${BUILD_DIRECTORY}/repositories/empty' into ${BUILD_DIRECTORY}/projects/empty
+Please provide branchout name [empty]: 
+Branchout state will be stored in ${BUILD_DIRECTORY}/branchout/empty
+Please provide your git author email: 
+Set the git author to stickycode@example.com"
+}
+
+@test "branchout init - from url using supplied branchout and existing author email" {
+  HOME=${BUILD_DIRECTORY}
+  run branchout init file://${BUILD_DIRECTORY}/repositories/empty reuse-branchout <<< "reuse-branchout
+stickycode@example.com"
+  assert_success "Branchout projected 'file://${BUILD_DIRECTORY}/repositories/empty' into ${BUILD_DIRECTORY}/projects/reuse-branchout
+Please provide branchout name [empty]: 
+Branchout state will be stored in ${BUILD_DIRECTORY}/branchout/reuse-branchout
+Please provide your git author email: 
+Set the git author to stickycode@example.com"
+
+  run branchout init file://${BUILD_DIRECTORY}/repositories/empty reuse-state <<< "reuse-branchout
+stickycode@example.com"
+  assert_success "Branchout projected 'file://${BUILD_DIRECTORY}/repositories/empty' into ${BUILD_DIRECTORY}/projects/reuse-state
+Please provide branchout name [empty]: 
+Branchout state will be stored in ${BUILD_DIRECTORY}/branchout/reuse-branchout
+Set the git author to stickycode@example.com"
+}
+
+@test "branchout init - from url.git" {
+  HOME=${BUILD_DIRECTORY}
+  run branchout init file://${BUILD_DIRECTORY}/repositories/ghbase.git <<< "stickycode@example.com"
+  assert_success "Branchout projected 'file://${BUILD_DIRECTORY}/repositories/ghbase.git' into ${BUILD_DIRECTORY}/projects/ghbase
+Branchout state will be stored in ${BUILD_DIRECTORY}/branchout/ghbase
+Please provide your git author email: 
+Set the git author to stickycode@example.com"
+  cd "${BUILD_DIRECTORY}/projects/ghbase"
   run branchout status
   assert_success_file_sort init/from-url
   run branchout add toad-gemel
   assert_success_file_sort init/with-toad
 }
 
-@test "branchout init from url.git with local name" {
+@test "branchout init - from url.git with local rename" {
   HOME=${BUILD_DIRECTORY}
-  run branchout init file://${BUILD_DIRECTORY}/repositories/ghbase.git localname
-  assert_success "Cloning into 'localname'...
-BRANCHOUT_GIT_BASEURL=file://${BUILD_DIRECTORY}/repositories"
-  cd target/projects/localname
+  run branchout init file://${BUILD_DIRECTORY}/repositories/ghbase.git localname <<< "stickycode@example.com"
+  assert_success "Branchout projected 'file://${BUILD_DIRECTORY}/repositories/ghbase.git' into ${BUILD_DIRECTORY}/projects/localname
+Branchout state will be stored in ${BUILD_DIRECTORY}/branchout/ghbase
+Set the git author to stickycode@example.com"
+  cd "${BUILD_DIRECTORY}/projects/localname"
   run branchout status
   assert_success_file_sort init/from-url
   run branchout add toad-gemel
   assert_success_file_sort init/with-toad
 }
 
-@test "branchout init not in git repository" {
-  mkdir -p target/tests/init-notgit
-  cd target/tests/init-notgit
+inEmptyDirectory() {
+  mkdir -p "${BUILD_DIRECTORY}/tests/${1}"
+  cd "${BUILD_DIRECTORY}/tests/${1}" || exit 77
   HOME=${BUILD_DIRECTORY}
-  run branchout init <<< 'init'
-  assert_error "${BUILD_DIRECTORY}/tests/init-notgit is not a git repository, try git init first"
 }
 
-@test "branchout init in git repository, no branchout" {
-  mkdir -p target/tests/init-ingit
-  cd target/tests/init-ingit
+inEmptyProject() {
+  mkdir -p "${BUILD_DIRECTORY}/projects/${1}"
+  cd "${BUILD_DIRECTORY}/projects/${1}" || exit 77
   HOME=${BUILD_DIRECTORY}
-  git init
+}
+
+@test "branchout init - new projection needs a url" {
+  inEmptyDirectory "prompt-for-projection-url"
   run branchout init <<< ''
-  assert_error "Enter branchout name [init-ingit]: "
+  assert_failure "Please provide projection url: 
+Error: You must supply a value for projection url"
 }
 
-@test "branchout init in git repository, interactive" {
-  mkdir -p target/tests/init-interactive
-  cd target/tests/init-interactive
+@test "branchout init - new projection defaults branchout name to project name" {
+  inEmptyDirectory "projection-name-is-default-branchout-name"
+  run branchout init <<< 'https://github.com/Branchout/example
+
+
+stickycode@example.com'
+  assert_success "Please provide projection url: 
+Please provide local project name [example]: 
+Branchout projection for 'https://github.com/Branchout/example' created in ${BUILD_DIRECTORY}/projects/example
+Please provide branchout name [example]: 
+Branchout state will be stored in ${BUILD_DIRECTORY}/branchout/example
+Please provide your git author email: 
+Set the git author to stickycode@example.com"
+}
+
+@test "branchout init - new projection errors if name is already used" {
+  inEmptyDirectory "init-already-exists"
+  run branchout init <<< 'https://github.com/Branchout/already-exists
+
+
+stickycode@example.com'
+  assert_success "Please provide projection url: 
+Please provide local project name [already-exists]: 
+Branchout projection for 'https://github.com/Branchout/already-exists' created in ${BUILD_DIRECTORY}/projects/already-exists
+Please provide branchout name [already-exists]: 
+Branchout state will be stored in ${BUILD_DIRECTORY}/branchout/already-exists
+Please provide your git author email: 
+Set the git author to stickycode@example.com"
+  run branchout init <<< 'https://github.com/Branchout/already-exists'
+  assert_failure "Please provide projection url: 
+Please provide local project name [already-exists]: 
+Branchout projection already exists at ${BUILD_DIRECTORY}/projects/already-exists
+
+branchout-init [git-url] [relocation]
+
+  To branchout from GitHub and use the repository name for the projection
+
+    branchout init https://github.com/branchout/branchout-project
+
+  To branchout from GitHub and use a different name for the projection
+
+    branchout init https://github.com/branchout/branchout-project branchout
+
+  To interactively initialise a projection locally
+
+    branchout init"
+}
+
+@test "branchout init - new projection requires git url to setup git" {
+  inEmptyProject init-new-requires-url
+  run branchout init <<< ''
+  assert_failure "Branchout projection created in ${BUILD_DIRECTORY}/projects/init-new-requires-url
+Please provide projection url: 
+Error: You must supply a value for projection url"
+}
+
+@test "branchout init - new projection url git url to setup git" {
+  inEmptyProject init-new-projection
+  run branchout init <<< 'https://github.com/Branchout/new-projection
+
+stickycode@example.com'
+  assert_success "Branchout projection created in ${BUILD_DIRECTORY}/projects/init-new-projection
+Please provide projection url: 
+Please provide branchout name [new-projection]: 
+Branchout state will be stored in ${BUILD_DIRECTORY}/branchout/new-projection
+Please provide your git author email: 
+Set the git author to stickycode@example.com"
+  run git remote get-url origin
+  assert_success "https://github.com/Branchout/new-projection"
+}
+
+function inEmptyRepository() {
+  test -d "${BUILD_DIRECTORY}/projects/${1}" && bail "project ${BUILD_DIRECTORY}/projects/${1} already exists"
+  git clone "file://${BUILD_DIRECTORY}/repositories/empty" "${BUILD_DIRECTORY}/projects/${1}"
+  cd "${BUILD_DIRECTORY}/projects/${1}" || exit 77
   HOME=${BUILD_DIRECTORY}
-  git init
-  run branchout init <<< "brname
-gitty"
-  assert_success
+}
+
+@test "branchout init - in git repository, no branchout requires name uses default" {
+  inEmptyRepository "init-in-git-require-name-uses-default"
+  run branchout init <<< ''
+  assert_success "Please provide branchout name [empty]: 
+Branchout state will be stored in ${BUILD_DIRECTORY}/branchout/empty
+Set the git author to stickycode@example.com"
+}
+
+@test "branchout init - in git repository, no branchout requires name" {
+  inEmptyRepository "init-in-git-require-name"
+  run branchout init <<< 'init-in-git-require-name
+stickycode@example.com'
+  assert_success "Please provide branchout name [empty]: 
+Branchout state will be stored in ${BUILD_DIRECTORY}/branchout/init-in-git-require-name
+Please provide your git author email: 
+Set the git author to stickycode@example.com"
+}
+
+@test "branchout init - in git repository, interactive" {
+  inEmptyRepository "init-in-git-interactive"
+  run branchout init <<< "init-in-git-interactive
+stickycode@example.com"
+  assert_success "Please provide branchout name [empty]: 
+Branchout state will be stored in ${BUILD_DIRECTORY}/branchout/init-in-git-interactive
+Please provide your git author email: 
+Set the git author to stickycode@example.com"
   run branchout status
   assert_error "No projects to show, try branchout add <project-name>"
 }
 
-@test "branchout init in git repository, add projects" {
-  mkdir -p target/tests/init-git 
-  cd target/tests/init-git
-  HOME=${BUILD_DIRECTORY}
-  git init
-  run branchout init <<< "brname
-gitty"
-  assert_success
+@test "branchout init - in git repository, add projects" {
+  inEmptyRepository "init-in-git-add-project"
+  run branchout init <<< "
+stickycode@example.com"
+  assert_success "Please provide branchout name [empty]: 
+Branchout state will be stored in ${BUILD_DIRECTORY}/branchout/empty
+Set the git author to stickycode@example.com"
   run branchout status
   assert_error "No projects to show, try branchout add <project-name>"
   run branchout add frog-aleph
   assert_success_file status/no-clone
 }
 
-@test "branchout init from url then clone projects" {
-  HOME=${BUILD_DIRECTORY}
-  
-  run branchout init file://${BUILD_DIRECTORY}/repositories/base clone
-  assert_success "Cloning into 'clone'...
-BRANCHOUT_GIT_BASEURL=file://${BUILD_DIRECTORY}/repositories"
+@test "branchout init - in git repository, clone projects" {
+  inEmptyRepository "init-in-git-clone-projects"
+  run branchout init <<< "init-in-git-clone-projects
+stickycode@example.com"
+  assert_success "Please provide branchout name [empty]: 
+Branchout state will be stored in ${BUILD_DIRECTORY}/branchout/init-in-git-clone-projects
+Please provide your git author email: 
+Set the git author to stickycode@example.com"
+  run branchout status
+  assert_error "No projects to show, try branchout add <project-name>"
+  run branchout clone toad-aleph
+  assert_success_file clone/clone-one
+}
 
-  cd target/projects/clone
+function inBaseRepository() {
+  test -d "${BUILD_DIRECTORY}/projects/${1}" && bail "project ${BUILD_DIRECTORY}/projects/${1} already exists"
+  HOME=${BUILD_DIRECTORY}
+  run branchout init "file://${BUILD_DIRECTORY}/repositories/projects" "${1}" <<< "${1}
+stickycode@example.com"
+  assert_success "Branchout projected 'file://${BUILD_DIRECTORY}/repositories/projects' into ${BUILD_DIRECTORY}/projects/${1}
+Please provide branchout name [projects]: 
+Branchout state will be stored in ${BUILD_DIRECTORY}/branchout/${1}
+Please provide your git author email: 
+Set the git author to stickycode@example.com"
+  cd "${BUILD_DIRECTORY}/projects/${1}" || exit 77
+}
+
+@test "branchout init - from url, then clone projects" {
+  inBaseRepository init-from-url-clone
+
   run branchout status
   assert_success_file_sort init/from-url
   run branchout clone toad-aleph
   assert_success_file clone/clone-one
 }
 
-@test "branchout init from url then clone projects with group folder" {
-  HOME=${BUILD_DIRECTORY}
-  
-  run branchout init file://${BUILD_DIRECTORY}/repositories/base clone-folder
-  assert_success "Cloning into 'clone-folder'...
-BRANCHOUT_GIT_BASEURL=file://${BUILD_DIRECTORY}/repositories"
+@test "branchout init - from url then clone projects with group folder" {
+  inBaseRepository init-from-url-clone-folder
 
-  cd target/projects/clone-folder
   run branchout status
   assert_success_file_sort init/from-url
+
   mkdir toad
   run branchout clone toad-aleph
   assert_success_file status/clone-one-with-group-folder
 }
 
-@test "branchout init from url with flat structure" {
-  HOME=${BUILD_DIRECTORY}
-  run branchout init file://${BUILD_DIRECTORY}/repositories/frog
-  assert_success "Cloning into 'frog'...
-BRANCHOUT_GIT_BASEURL=file://${BUILD_DIRECTORY}/repositories"
-  cd target/projects/frog
+@test "branchout init - from url with flat structure" {
+  inBaseRepository frog
+
   run branchout pull frog
   assert_success_file_sort init/from-url-with-flat-structure
 }
 
-@test "branchout init with relocated projects folder" {
+@test "branchout init - with relocated projects folder" {
   HOME=${BUILD_DIRECTORY}/relocated
-  mkdir -p ${BUILD_DIRECTORY}/relocated/.config
-  echo "BRANCHOUT_PROJECTS_DIRECTORY=notprojects" > ${BUILD_DIRECTORY}/relocated/.config/branchoutrc
-  run branchout init file://${BUILD_DIRECTORY}/repositories/frog
-  assert_success "Cloning into 'frog'...
-BRANCHOUT_GIT_BASEURL=file://${BUILD_DIRECTORY}/repositories"
-  cd target/relocated/notprojects/frog
+  mkdir -p "${BUILD_DIRECTORY}/relocated/.config"
+  echo "BRANCHOUT_PROJECTS_DIRECTORY=notprojects" > "${BUILD_DIRECTORY}/relocated/.config/branchoutrc"
+
+  run branchout init file://${BUILD_DIRECTORY}/repositories/frog <<< "stickycode@example.com"
+  assert_success "Branchout projected 'file://${BUILD_DIRECTORY}/repositories/frog' into ${BUILD_DIRECTORY}/relocated/notprojects/frog
+Branchout state will be stored in ${BUILD_DIRECTORY}/relocated/branchout/frog
+Please provide your git author email: 
+Set the git author to stickycode@example.com"
+
+  cd "${BUILD_DIRECTORY}/relocated/notprojects/frog"
   run branchout pull frog
   assert_success_file_sort init/from-url-with-flat-structure
+}
+
+@test "branchout init - local then add projects" {
+  HOME=${BUILD_DIRECTORY}
+  run branchout-init <<< "file://${BUILD_DIRECTORY}/repositories/frog
+init-local-then-add
+init-local-then-add
+stickycode@example.com"
+  assert_success "Please provide projection url: 
+Please provide local project name [frog]: 
+Branchout projection for 'file://${BUILD_DIRECTORY}/repositories/frog' created in ${BUILD_DIRECTORY}/projects/init-local-then-add
+Please provide branchout name [frog]: 
+Branchout state will be stored in ${BUILD_DIRECTORY}/branchout/init-local-then-add
+Please provide your git author email: 
+Set the git author to stickycode@example.com"
+  cd target/projects/init-local-then-add
+  run branchout status
+  assert_error "No projects to show, try branchout add <project-name>"
+  run branchout add frog-aleph
+  assert_success_file status/no-clone
+  run branchout status frog-aleph
+  assert_success_file status/no-clone
+  run branchout add frog-beta
+  assert_success_file_sort status/two-no-clone
+}
+
+@test "branchout init - only sets url and name" {
+  HOME=${BUILD_DIRECTORY}
+  run branchout-init <<< "init-branchoutfile
+
+
+stickycode@example.com"
+  assert_success "Please provide projection url: 
+Please provide local project name [init-branchoutfile]: 
+Branchout projection for 'init-branchoutfile' created in ${BUILD_DIRECTORY}/projects/init-branchoutfile
+Please provide branchout name [init-branchoutfile]: 
+Branchout state will be stored in ${BUILD_DIRECTORY}/branchout/init-branchoutfile
+Please provide your git author email: 
+Set the git author to stickycode@example.com"
+  cd "${BUILD_DIRECTORY}/projects/init-branchoutfile"
+  run branchout status
+  assert_error "No projects to show, try branchout add <project-name>"
+  assert_equal "BRANCHOUT_NAME=\"init-branchoutfile\"" "$(cat Branchoutfile)"
 }

--- a/bats/branchout-yarn.bats
+++ b/bats/branchout-yarn.bats
@@ -12,7 +12,7 @@ load helper
 }
 
 @test "branchout yarn - ask for settings" {
-  example yarn-settings
+  prefixExample yarn-settings
   run branchout yarn settings <<< "https://yarn.example.org/repository/npm-example
 npmuser
 supersecret
@@ -31,7 +31,7 @@ writing npm config to ../branchout/yarn-settings/node/.npmrc"
 }
 
 @test "branchout yarn - ask for settings again only asks for secret" {
-  example yarn-settings-twice
+  prefixExample yarn-settings-twice
   run branchout yarn settings <<< "https://yarn.example.org/repository/npm-example
 npmuser
 supersecret
@@ -58,7 +58,7 @@ writing npm config to ../branchout/yarn-settings-twice/node/.npmrc"
 }
 
 @test "branchout yarn - use existing settings" {
-  example yarn-use-existing-settings
+  prefixExample yarn-use-existing-settings
   run branchout set NPM_REGISTRY "https://yarn.example.org/repository/npm-example"
   assert_success
   run branchout set-config NPM_USER npmuser
@@ -78,7 +78,7 @@ writing npm config to ../branchout/yarn-use-existing-settings/node/.npmrc"
 
 
 @test "branchout yarn - missing registry fails" {
-  example yarn-settings-missing-registry
+  prefixExample yarn-settings-missing-registry
   run branchout yarn clean <<<  "
 "
   assert_failure "Please provide your npm registry: 
@@ -86,7 +86,7 @@ Error: You must supply a value for your npm registry"
 }
 
 @test "branchout yarn - missing npm user fails" {
-  example yarn-settings-missing-npm-username
+  prefixExample yarn-settings-missing-npm-username
   run branchout yarn clean <<<  "https://yarn.example.org/repository/npm-example
 
 "
@@ -96,7 +96,7 @@ Error: You must supply a value for npm registry username"
 }
 
 @test "branchout yarn - missing npm pass fails" {
-  example yarn-settings-missing-npm-password
+  prefixExample yarn-settings-missing-npm-password
   run branchout yarn clean <<<  "https://yarn.example.org/repository/npm-example
 npmuser
 
@@ -108,7 +108,7 @@ Error: You must supply a value for npm registry secret"
 }
 
 @test "branchout yarn - missing npm email fails" {
-  example yarn-settings-missing-npm-email
+  prefixExample yarn-settings-missing-npm-email
   run branchout yarn clean <<<  "https://yarn.example.org/repository/npm-example
 npmuser
 supersecret
@@ -121,7 +121,7 @@ Error: You must supply a value for npm registry email (git commit author)"
 }
 
 @test "branchout yarn - ask for settings always https" {
-  example yarn-settings-https
+  prefixExample yarn-settings-https
   run branchout yarn clean <<<  "http://yarn.example.org/repository/npm-example
 npmuser
 supersecret

--- a/bats/branchout.bats
+++ b/bats/branchout.bats
@@ -31,7 +31,6 @@ load helper
   HOME=..
   cd target/missing-branchout-home
   echo 'BRANCHOUT_NAME="missing-branchout-home"' > Branchoutfile
-  echo 'BRANCHOUT_GIT_BASEURL="missing-branchout-home"' >> Branchoutfile
   run branchout status
   assert_error "Branchout home '../branchout/missing-branchout-home' does not exist, run branchout init"
 }
@@ -41,7 +40,6 @@ load helper
   cd target/no-projects
   HOME=..
   echo 'BRANCHOUT_NAME="no-projects"' > Branchoutfile
-  echo 'BRANCHOUT_GIT_BASEURL="no-projects"' >> Branchoutfile
   run branchout status
   assert_error "Branchoutprojects file missing, try branchout add [repository]"
 }
@@ -51,7 +49,6 @@ load helper
   cd target/prefix
   HOME=..
   echo 'BRANCHOUT_NAME="prefix"' > Branchoutfile
-  echo 'BRANCHOUT_GIT_BASEURL="prefix"' >> Branchoutfile
   echo 'BRANCHOUT_PREFIX="prefix"' >> Branchoutfile
   echo 'prefix-frog-aleph' > Branchoutprojects
   run branchout status

--- a/bats/helper.bash
+++ b/bats/helper.bash
@@ -123,10 +123,12 @@ example() {
   test -z "$1" && bail "examples need a name"
   test -d "target/${1}" && bail "example already exists: ${1}"
   mkdir -p "target/${1}" "target/branchout/${1}"
+  echo "BRANCHOUT_CONFIG_GIT_EMAIL=\"${1}@example.com\"" > "target/branchout/${1}/branchoutrc"
   cd "target/${1}" || bail "Failed to enter target/${1}"
+  git init 2>/dev/null 1>&2 || bail "failed to initilise the git repository"
+  git remote add origin file://${BUILD_DIRECTORY}/repositories/base 2>/dev/null 1>&2 || bail "failed to set the origin which is needed to derive base url"
   export HOME=..
   echo "BRANCHOUT_NAME=\"${1}\"" > Branchoutfile
-  echo "BRANCHOUT_GIT_BASEURL=\"file://${BUILD_DIRECTORY}/repositories\"" >> Branchoutfile
   echo "frog-aleph
 frog-gemel
 frog-bet
@@ -169,13 +171,14 @@ fox-gemel" > .projects
 }
 
 prefixExample() {
-  test -z "$1" && bail "exmaples need a name"
+  test -z "$1" && bail "examples need a name"
   test -d "target/${1}" && bail "example already exists: ${1}"
   mkdir -p "target/${1}" "target/branchout/${1}"
   cd "target/${1}" || bail "Failed to enter target/${1}"
-  export HOME=../
+  git init 2>/dev/null 1>&2 || bail "failed to initilise the git repository"
+  git remote add origin file://${BUILD_DIRECTORY}/repositories/base 2>/dev/null 1>&2 || bail "failed to set the origin which is needed to derive base url"
+  export HOME=..
   echo "BRANCHOUT_NAME=\"${1}\"" > Branchoutfile
-  echo "BRANCHOUT_GIT_BASEURL=\"file://${BUILD_DIRECTORY}/repositories\"" >> Branchoutfile
   echo "BRANCHOUT_PREFIX=\"prefix\"" >> Branchoutfile
   echo "toad-aleph
 toad-gemel

--- a/bats/legacy.bats
+++ b/bats/legacy.bats
@@ -8,14 +8,6 @@ load helper
   assert_error "Branchout name not defined in .branchout, run branchout init" 
 }
 
-@test "legacy branchout configuration missing BRANCHOUT_GIT_BASEURL fails" {
-  mkdir -p target/legacy/missing-giturl target/branchout/missing-giturl 
-  cd target/legacy/missing-giturl
-  echo 'BRANCHOUT_NAME="missing-giturl"' > .branchout 
-  run branchout status
-  assert_error "Git base url is not defined in .branchout, run branchout init" 
-}
-
 @test "legacy branchout home is missing fails" {
   mkdir -p target/legacy/missing-branchout-home 
   HOME=${BUILD_DIRECTORY}
@@ -49,7 +41,17 @@ load helper
 }
 
 @test "legacy can pull all" {
-  legacyExample legacy-pull-all
+  HOME=${BUILD_DIRECTORY}
+  run branchout init file://${BUILD_DIRECTORY}/repositories/legacy "legacy-pull-all" <<< "legacy-pull-all@example.com"
+  assert_success "Branchout projected 'file://${BUILD_DIRECTORY}/repositories/legacy' into ${BUILD_DIRECTORY}/projects/legacy-pull-all
+Branchout state will be stored in ${BUILD_DIRECTORY}/branchout/legacy
+Please provide your git author email: 
+Set the git author to legacy-pull-all@example.com"
+
+  cd target/projects/legacy-pull-all
+  run branchout status
+  assert_success_file_sort init/from-url
+  
   run branchout project status frog-aleph
   assert_success_file all/frog-aleph-before-pull
   run branchout pull
@@ -60,9 +62,11 @@ load helper
 
 @test "legacy branchout init from url" {
   HOME=${BUILD_DIRECTORY}
-  run branchout init file://${BUILD_DIRECTORY}/repositories/legacy
-  assert_success "Cloning into 'legacy'...
-BRANCHOUT_GIT_BASEURL=file://${BUILD_DIRECTORY}/repositories"
+  run branchout init file://${BUILD_DIRECTORY}/repositories/legacy <<< ""
+  assert_success "Branchout projected 'file://${BUILD_DIRECTORY}/repositories/legacy' into ${BUILD_DIRECTORY}/projects/legacy
+Branchout state will be stored in ${BUILD_DIRECTORY}/branchout/legacy
+Set the git author to legacy-pull-all@example.com"
+
   cd target/projects/legacy
   run branchout status
   assert_success_file_sort init/from-url

--- a/branchout
+++ b/branchout
@@ -106,6 +106,7 @@ function execute() {
     . "${BRANCHOUT_PATH}/branchout-configuration"
     # shellcheck source=branchout-environment
     . "${BRANCHOUT_PATH}/branchout-environment"
+
     eval branchout_"${branchoutModule}" "${@}"
 
   elif test -x "${BRANCHOUT_PATH}/branchout-${branchoutModule}"; then

--- a/branchout-environment
+++ b/branchout-environment
@@ -53,7 +53,8 @@ export BRANCHOUT_NAME
 BRANCHOUT_STATE="${HOME}/branchout/${BRANCHOUT_NAME}"
 export BRANCHOUT_STATE
 
-test -z "${BRANCHOUT_GIT_BASEURL}" && usage "Git base url is not defined in ${BRANCHOUT_FILE}, run branchout init"
+BRANCHOUT_GIT_BASEURL="$(git remote get-url origin 2>/dev/null | sed -e 's,/[^/]*$,,')"
+test -z "${BRANCHOUT_GIT_BASEURL}" && fail "The project directory is not a git repository, run branchout init"
 export BRANCHOUT_GIT_BASEURL
 export BRANCHOUT_PREFIX
 

--- a/branchout-init
+++ b/branchout-init
@@ -20,78 +20,98 @@ function branchoutFiles() {
   return 1
 }
 
-function branchout_init_name() {
-  DEFAULT_BRANCHOUT_NAME="$(basename "${PWD}")"
-  printf "Enter branchout name [%s]: " "${DEFAULT_BRANCHOUT_NAME}"
-  read -r BRANCHOUT_NAME
-  if test -z "${BRANCHOUT_NAME}"; then
-     BRANCHOUT_NAME="${DEFAULT_BRANCHOUT_NAME}"
-     echo
+function ensureBranchoutFiles() {
+  if ! branchoutFiles "${PWD}"; then
+    BRANCHOUT_FILE=Branchoutfile
+    BRANCHOUT_PROJECTS=Branchoutprojects
+    touch Branchoutfile
+    test -f Branchoutprojects || touch Branchoutprojects
   fi
-}
-
-function branchout_init_baseurl()  {
-  BRANCHOUT_GIT_BASEURL="$(git remote get-url origin 2>/dev/null| sed -e 's,/[^/]*$,,')"  || true
-  if test -z "${BRANCHOUT_GIT_BASEURL}"; then
-    printf "Enter git baseurl: "
-    read -r BRANCHOUT_GIT_BASEURL || true
-    test -z "${BRANCHOUT_GIT_BASEURL}" && usage "git baseurl is not defined"
-  fi
-
-  return 0
-}
+ }
 
 function branchoutInitFromUrl() {
-  test -d "${HOME}/${BRANCHOUT_PROJECTS_DIRECTORY}" || mkdir -p "${HOME}/${BRANCHOUT_PROJECTS_DIRECTORY}"
-  cd "${HOME}/${BRANCHOUT_PROJECTS_DIRECTORY}"
-  BRANCHOUT_NAME="$(basename "${1}" | sed -e 's,.git$,,')"
-  test -n "${2}" && BRANCHOUT_NAME="${2}"
-  test -d "${BRANCHOUT_NAME}" && usage "${HOME}/${BRANCHOUT_PROJECTS_DIRECTORY}/${BRANCHOUT_NAME} is already initialised"
-  git clone "${1}" "${BRANCHOUT_NAME}" || usage "Failed to clone ${1}"
-  cd "${BRANCHOUT_NAME}"
+  DEFAULT_BRANCHOUT_NAME="$(basename "${1}" | sed -e 's,.git$,,')"
+  PROJECT_NAME="${2:-${DEFAULT_BRANCHOUT_NAME}}"
+  export PROJECTION_DIRECTORY="${HOME}/${BRANCHOUT_PROJECTS_DIRECTORY}/${PROJECT_NAME}"
+  test -d "${PROJECTION_DIRECTORY}" && usage "Branchout projection already exists at ${PROJECTION_DIRECTORY}"
+  git clone "${1}" "${PROJECTION_DIRECTORY}" >/dev/null 2>&1 || usage "Failed to branchout projection ${1} into ${PROJECTION_DIRECTORY}" "$(git clone "${1}" "${PROJECTION_DIRECTORY}")"
+  echo "Branchout projected '${1}' into ${PROJECTION_DIRECTORY}"
+  cd "${PROJECTION_DIRECTORY}" || usage "Failed to enter projection directory ${PROJECTION_DIRECTORY}"
+
+  branchoutInit
+}
+
+function branchoutExistingProjection() {
+  PROJECT_NAME="$(basename "$(pwd)")"
+  export PROJECTION_DIRECTORY="${HOME}/${BRANCHOUT_PROJECTS_DIRECTORY}/${PROJECT_NAME}"
+  if ! test -d "${HOME}/${BRANCHOUT_PROJECTS_DIRECTORY}/${PROJECT_NAME}/.git"; then
+    git init > /dev/null 2>&1
+    echo "Branchout projection created in $(pwd)"
+  fi
+  if git remote get-url origin >/dev/null 2>&1; then
+    DEFAULT_BRANCHOUT_NAME="$(basename "$(git remote get-url origin)" | sed -e 's,.git$,,')"
+  else
+    readValue "projection url" PROJECTION_URL
+    DEFAULT_BRANCHOUT_NAME="$(basename "${PROJECTION_URL}" | sed -e 's,.git$,,')"
+    git remote add origin "${PROJECTION_URL}"
+  fi
 
   branchoutInit
 }
 
 function branchoutInitLocal() {
-  test -d .git || usage "$(pwd) is not a git repository, try git init first"
+  readValue "projection url" PROJECTION_URL
+  DEFAULT_BRANCHOUT_NAME="$(basename "${PROJECTION_URL}" | sed -e 's,.git$,,')"
+  readValue "local project name" "PROJECT_NAME" "${DEFAULT_BRANCHOUT_NAME}"
+
+  export PROJECTION_DIRECTORY="${HOME}/${BRANCHOUT_PROJECTS_DIRECTORY}/${PROJECT_NAME}"
+  test -d "${PROJECTION_DIRECTORY}" && usage "Branchout projection already exists at ${PROJECTION_DIRECTORY}"
+  git init "${PROJECTION_DIRECTORY}" >/dev/null 2>&1
+  cd "${PROJECTION_DIRECTORY}" || usage "Cannot enter project directory ${PROJECTION_DIRECTORY}"
+  echo "Branchout projection for '${PROJECTION_URL}' created in ${PROJECTION_DIRECTORY}"
+  git remote add origin "${PROJECTION_URL}"
+
   branchoutInit
 }
 
-function branchoutDefaultFiles() {
-   BRANCHOUT_FILE=Branchoutfile
-   BRANCHOUT_PROJECTS=Branchoutprojects
-   touch Branchoutfile
-   test -f Branchoutprojects || touch Branchoutprojects
- }
-
 function branchoutInit() {
-  if ! branchoutFiles "${PWD}"; then
-    branchoutDefaultFiles
-  fi
+  ensureBranchoutFiles
 
   # shellcheck source=examples/Branchoutfile
   source "${BRANCHOUT_FILE}"
 
-  if test -z "${BRANCHOUT_NAME}"; then
-    branchout_init_name
-    echo "BRANCHOUT_NAME=${BRANCHOUT_NAME}" | tee -a ${BRANCHOUT_FILE}
-  fi
-
+  ensureValue "branchout name" "NAME" "${DEFAULT_BRANCHOUT_NAME}"
   test -d "${HOME}/branchout/${BRANCHOUT_NAME}" || mkdir -p "${HOME}/branchout/${BRANCHOUT_NAME}"
+  export BRANCHOUT_STATE="${HOME}/branchout/${BRANCHOUT_NAME}"
+  echo "Branchout state will be stored in ${HOME}/branchout/${BRANCHOUT_NAME}"
+  # shellcheck source=examples/branchoutrc
+  test -f "${BRANCHOUT_STATE}/branchoutrc" && source "${BRANCHOUT_STATE}/branchoutrc"
 
-  if test -z "${BRANCHOUT_GIT_BASEURL}"; then
-    branchout_init_baseurl
-    echo "BRANCHOUT_GIT_BASEURL=${BRANCHOUT_GIT_BASEURL}" | tee -a ${BRANCHOUT_FILE}
+  if git config user.email; then 
+    echo "Git author is set to $(git config user.email)"
+  else
+    ensureConfigValue "your git author email" "GIT_EMAIL"
+    git config user.email "${BRANCHOUT_CONFIG_GIT_EMAIL}"
+    echo "Set the git author to ${BRANCHOUT_CONFIG_GIT_EMAIL}"
   fi
-
 }
 
 function usage() {
-  test -n "${1}" && echo "${1}" && echo
+  test $# -gt 0  && echo "${@}" && echo
   echo "branchout-init [git-url] [relocation]
 
-  "
+  To branchout from GitHub and use the repository name for the projection
+
+    branchout init https://github.com/branchout/branchout-project
+
+  To branchout from GitHub and use a different name for the projection
+
+    branchout init https://github.com/branchout/branchout-project branchout
+
+  To interactively initialise a projection locally
+
+    branchout init
+"
 
   exit 1
 }
@@ -105,8 +125,12 @@ function main() {
   if test -n "${1}"; then
     branchoutInitFromUrl "${1}" "${2}"
 
+  elif test "$(dirname "$(pwd)")" = "${HOME}/${BRANCHOUT_PROJECTS_DIRECTORY}"; then
+    branchoutExistingProjection
+  
   else
     branchoutInitLocal
+
   fi
 
   export BRANCHOUT_PROJECTS

--- a/examples/make-repositories
+++ b/examples/make-repositories
@@ -2,6 +2,20 @@
 
 set -e
 
+makeEmpty() {
+  rm -rf ${1}
+  mkdir ${1}
+  pushd ${1}
+  git init
+  git config user.email "someone@example.com";
+  git config user.name "hopefully_not_real";
+
+  echo "# ${each}" > README.md;
+  git add README.md
+  git commit --no-gpg-sign -a -m"Initial commit";
+  popd
+}
+
 makeBase() {
   rm -rf ${1}
   mkdir ${1}
@@ -14,7 +28,26 @@ makeBase() {
   echo "frog-aleph
 frog-gemel
 toad-aleph" > Branchoutprojects
-  echo "BRANCHOUT_NAME=${1}" > Branchoutfile
+  echo "BRANCHOUT_NAME=${2:-${1}}" > Branchoutfile
+  git add README.md Branchoutprojects Branchoutfile;
+  git commit --no-gpg-sign -a -m"Initial commit";
+
+  popd
+}
+
+makeProjects() {
+  rm -rf ${1}
+  mkdir ${1}
+  pushd ${1}
+  git init
+  git config user.email "someone@example.com";
+  git config user.name "hopefully_not_real";
+
+  echo "# ${each}" > README.md;
+  echo "frog-aleph
+frog-gemel
+toad-aleph" > Branchoutprojects
+  touch Branchoutfile
   git add README.md Branchoutprojects Branchoutfile;
   git commit --no-gpg-sign -a -m"Initial commit";
 
@@ -116,7 +149,9 @@ each=lion counter=aleph makeProject
 
 # Setup base projects for init testing
 makeBase base
-makeBase ghbase.git
+makeBase ghbase.git ghbase
+makeEmpty empty
+makeProjects projects
 
 # Legacy files .branchout and .projects are supported
 makeLegacyBase legacy


### PR DESCRIPTION
This will seamlessly allow for https and ssh to be used on the same metarepo by deriving the git base url from how the metarepo was cloned

fixes #56 
fixes #10