### PR TITLE
Add branchout relocate feature for migrating from one saas Git provider to another…

### DIFF
--- a/bats/branchout.bats
+++ b/bats/branchout.bats
@@ -112,10 +112,10 @@ load helper
   assert_string_present "Relocation complete. To reverse what you just did, run 'branchout relocate"
 
   # Covers all three layers and case of remotes not called origin and case of nested project URLs
-  assert_equal "$(git remote get-url origin)" "${NEW_BASE}/base"
-  assert_equal "$(git --git-dir=base/.git remote get-url origin)" "${NEW_BASE}/base"
-  assert_equal "$(git --git-dir=group/.git remote get-url sample)" "${NEW_BASE}/group"
-  assert_equal "$(git --git-dir=group/project/.git remote get-url upstream)" "${NEW_BASE}/group/project"
+  assert_equal "${NEW_BASE}/base" "$(git remote get-url origin)"
+  assert_equal "${NEW_BASE}/base" "$(git --git-dir=base/.git remote get-url origin)"
+  assert_equal "${NEW_BASE}/group" "$(git --git-dir=group/.git remote get-url sample)"
+  assert_equal "${NEW_BASE}/group/project" "$(git --git-dir=group/project/.git remote get-url upstream)"
 }
 
 @test "branchout add no params should error" {

--- a/bats/branchout.bats
+++ b/bats/branchout.bats
@@ -97,12 +97,6 @@ load helper
   run branchout relocate "${NEW_BASE}"
   assert_success_only # Command must succeed, then check details
 
-  # Covers all three layers and case of remotes not called origin and case of nested project URLs
-  assert_equal "$(git remote get-url origin)" "${NEW_BASE}/base"
-  assert_equal "$(git --git-dir=base/.git remote get-url origin)" "${NEW_BASE}/base"
-  assert_equal "$(git --git-dir=group/.git remote get-url sample)" "${NEW_BASE}/group"
-  assert_equal "$(git --git-dir=group/project/.git remote get-url upstream)" "${NEW_BASE}/group/project"
-
   # Validate the sanity check logic and human readable output. Note: dirs/URLs vary per test runner, so using partial matches
   assert_string_present "Relocating all Git repos from"
   assert_string_present "and all nested repos 1 and 2 levels deep."
@@ -116,6 +110,12 @@ load helper
   assert_string_present "Found 1 project .git/config files to process"
   assert_string_present "Processing a total of 4 .git/config files, including the base directory"
   assert_string_present "Relocation complete. To reverse what you just did, run 'branchout relocate"
+
+  # Covers all three layers and case of remotes not called origin and case of nested project URLs
+  assert_equal "$(git remote get-url origin)" "${NEW_BASE}/base"
+  assert_equal "$(git --git-dir=base/.git remote get-url origin)" "${NEW_BASE}/base"
+  assert_equal "$(git --git-dir=group/.git remote get-url sample)" "${NEW_BASE}/group"
+  assert_equal "$(git --git-dir=group/project/.git remote get-url upstream)" "${NEW_BASE}/group/project"
 }
 
 @test "branchout add no params should error" {

--- a/bats/branchout.bats
+++ b/bats/branchout.bats
@@ -114,7 +114,7 @@ load helper
   # This has to match what we actually had on disk:
   assert_string_present "Found 2 group .git/config files to process"
   assert_string_present "Found 1 project .git/config files to process"
-  assert_string_present "Processsing a total of 4 .git/config files, including the base directory"
+  assert_string_present "Processing a total of 4 .git/config files, including the base directory"
   assert_string_present "Relocation complete. To reverse what you just did, run 'branchout relocate"
 }
 

--- a/bats/branchout.bats
+++ b/bats/branchout.bats
@@ -92,6 +92,18 @@ load helper
   git init group/project > /dev/null
   git --git-dir=group/project/.git remote add upstream "${OLD_BASE}/group/project" # Example of a project within a branchout group
 
+  # Extra group for extra projects to prove arrays expand correctly
+  mkdir arrays
+  git init arrays > /dev/null
+  git --git-dir=arrays/.git remote add downstream "${OLD_BASE}/group"
+
+  # Extra 3 projects inside the arrays group
+  mkdir arrays/list arrays/vector arrays/map
+  git init arrays/list
+  git init arrays/vector
+  git init arrays/map
+  # don't really need to set the remotes, sed will just find less to do
+
   # Do the relocation and verify it worked
   NEW_BASE="${PREFIX}$(pwd)"
   run branchout relocate "${NEW_BASE}"
@@ -106,9 +118,9 @@ load helper
   assert_string_present "Validating the Git repo pointed at by the new URL above works..."
   assert_string_present "New URL exists and you have access, proceeding..."
   # This has to match what we actually had on disk:
-  assert_string_present "Found 2 group .git/config files to process"
-  assert_string_present "Found 1 project .git/config files to process"
-  assert_string_present "Processing a total of 4 .git/config files, including the base directory"
+  assert_string_present "Found 3 group .git/config files to process"
+  assert_string_present "Found 4 project .git/config files to process"
+  assert_string_present "Processing a total of 8 .git/config files, including the base directory"
   assert_string_present "Relocation complete. To reverse what you just did, run 'branchout relocate"
 
   # Covers all three layers and case of remotes not called origin and case of nested project URLs

--- a/bats/branchout.bats
+++ b/bats/branchout.bats
@@ -74,6 +74,9 @@ load helper
   PREFIX='file://'
   OLD_BASE="${PREFIX}$(dirname $(pwd))/repositories"
 
+  # Politics does not belong in code, but here we are:
+  git config --global init.defaultBranch slave
+
   # Must have "base" dir/repo to make remote check work correctly
   mkdir base
   git init base > /dev/null

--- a/bats/branchout.bats
+++ b/bats/branchout.bats
@@ -93,7 +93,7 @@ load helper
   git --git-dir=group/project/.git remote add upstream "${OLD_BASE}/group/project" # Example of a project within a branchout group
 
   # Do the relocation and verify it worked
-  NEW_BASE="${PREFIX}/$(pwd)"
+  NEW_BASE="${PREFIX}$(pwd)"
   run branchout relocate "${NEW_BASE}"
   assert_success_only # Command must succeed, then check details
 

--- a/bats/helper.bash
+++ b/bats/helper.bash
@@ -40,7 +40,9 @@ assert_success_only() {
 
 assert_string_present() {
   if ! echo "$output" | grep -q "${1}"; then
-    bail "String '${1}' not found in output!"
+    { echo "String '${1}' not found in output:"
+      echo "$output"
+    } | bail
   fi
 }
 

--- a/bats/helper.bash
+++ b/bats/helper.bash
@@ -30,6 +30,20 @@ assert_success_firstline() {
   fi
 }
 
+assert_success_only() {
+  if [ "$status" -ne 0 ]; then
+    { echo "command failed with exit status $status"
+      echo "output: $output"
+    } | bail
+  fi
+}
+
+assert_string_present() {
+  if ! echo "$output" | grep -q "${1}"; then
+    bail "String '${1}' not found in output!"
+  fi
+}
+
 assert_error_file() {
   if [ "$status" -eq 0 ]; then
     { echo "command should have failed"

--- a/branchout
+++ b/branchout
@@ -121,7 +121,8 @@ function branchout_relocate() {
 
   GROUP_CONFIG_FILE_PATTERN="${PROJECTION_DIRECTORY}/*/.git/config"
   if compgen -G "${GROUP_CONFIG_FILE_PATTERN}" > /dev/null; then
-    mapfile -t GROUP_CONFIG_FILES < <(compgen -G "${GROUP_CONFIG_FILE_PATTERN}")
+    GROUP_CONFIG_FILES=()
+    while IFS='' read -r configFile; do GROUP_CONFIG_FILES+=("$configFile"); done < <(compgen -G "${GROUP_CONFIG_FILE_PATTERN}")
     CONFIG_FILES=("${CONFIG_FILES[@]}" "${GROUP_CONFIG_FILES[@]}")
     echo "Found ${#GROUP_CONFIG_FILES[@]} group .git/config files to process"
   else
@@ -130,7 +131,8 @@ function branchout_relocate() {
 
   PROJECT_CONFIG_FILE_PATTERN="${PROJECTION_DIRECTORY}/*/*/.git/config"
   if compgen -G "${PROJECT_CONFIG_FILE_PATTERN}" > /dev/null; then
-    mapfile -t PROJECT_CONFIG_FILES < <(compgen -G "${PROJECT_CONFIG_FILE_PATTERN}")
+    PROJECT_CONFIG_FILES=()
+    while IFS='' read -r configFile; do PROJECT_CONFIG_FILES+=("$configFile"); done < <(compgen -G "${PROJECT_CONFIG_FILE_PATTERN}")
     CONFIG_FILES=("${CONFIG_FILES[@]}" "${PROJECT_CONFIG_FILES[@]}")
     echo "Found ${#PROJECT_CONFIG_FILES[@]} project .git/config files to process"
   else

--- a/branchout
+++ b/branchout
@@ -140,10 +140,10 @@ function branchout_relocate() {
   echo "Processing a total of ${#CONFIG_FILES[@]} .git/config files, including the base directory"
 
   if [ "$(branchout_os)" == "mac" ]; then
-    echo "We're on a mac, do weird OSX-specific sed in-place replacement"
+    test -n "${DEBUG}" && echo "We're on a mac, do weird OSX-specific sed in-place replacement"
     sed -i '' "s,${BRANCHOUT_GIT_BASEURL},${NEW_GIT_BASEURL}," "${CONFIG_FILES[@]}"
   else
-    echo "We're not on a mac, do normal sed in-place replacement"
+    test -n "${DEBUG}" && echo "We're not on a mac, do normal sed in-place replacement"
     sed -i "s,${BRANCHOUT_GIT_BASEURL},${NEW_GIT_BASEURL}," "${CONFIG_FILES[@]}"
   fi
   echo "Relocation complete. To reverse what you just did, run 'branchout relocate ${BRANCHOUT_GIT_BASEURL}'"

--- a/branchout
+++ b/branchout
@@ -119,20 +119,18 @@ function branchout_relocate() {
   # Collect together all of the Git config files to process
   CONFIG_FILES=("${PROJECTION_DIRECTORY}/.git/config")
 
-  GROUP_CONFIG_FILE_PATTERN="${PROJECTION_DIRECTORY}/*/.git/config"
-  if compgen -G "${GROUP_CONFIG_FILE_PATTERN}" > /dev/null; then
-    GROUP_CONFIG_FILES=()
-    while IFS='' read -r configFile; do GROUP_CONFIG_FILES+=("$configFile"); done < <(compgen -G "${GROUP_CONFIG_FILE_PATTERN}")
+  GROUP_CONFIG_FILES=()
+  while IFS='' read -r gitDirectory; do test -f "${gitDirectory}/config" && GROUP_CONFIG_FILES+=("${gitDirectory}/config"); done < <(find "${PROJECTION_DIRECTORY}" -mindepth 2 -maxdepth 2 -type d -name '.git')
+  if [ ${#GROUP_CONFIG_FILES[@]} -gt 0 ]; then
     CONFIG_FILES=("${CONFIG_FILES[@]}" "${GROUP_CONFIG_FILES[@]}")
     echo "Found ${#GROUP_CONFIG_FILES[@]} group .git/config files to process"
   else
     echo "No group .git/config files found to process."
   fi
 
-  PROJECT_CONFIG_FILE_PATTERN="${PROJECTION_DIRECTORY}/*/*/.git/config"
-  if compgen -G "${PROJECT_CONFIG_FILE_PATTERN}" > /dev/null; then
-    PROJECT_CONFIG_FILES=()
-    while IFS='' read -r configFile; do PROJECT_CONFIG_FILES+=("$configFile"); done < <(compgen -G "${PROJECT_CONFIG_FILE_PATTERN}")
+  PROJECT_CONFIG_FILES=()
+  while IFS='' read -r gitDirectory; do test -f "${gitDirectory}/config" && PROJECT_CONFIG_FILES+=("${gitDirectory}/config"); done < <(find "${PROJECTION_DIRECTORY}" -mindepth 3 -maxdepth 3 -type d -name '.git')
+  if [ ${#PROJECT_CONFIG_FILES[@]} -gt 0 ]; then
     CONFIG_FILES=("${CONFIG_FILES[@]}" "${PROJECT_CONFIG_FILES[@]}")
     echo "Found ${#PROJECT_CONFIG_FILES[@]} project .git/config files to process"
   else

--- a/branchout
+++ b/branchout
@@ -86,6 +86,69 @@ function branchout_os() {
   echo "${OS}"
 }
 
+# Update all Git URLs in 3 levels .git/config files that match the branchout Git base URL by prefix
+function branchout_relocate() {
+  if [ $# -ne 1 ]; then
+    fail "branchout relocate requires exactly one argument: The new Git URL base to apply to all remotes in all repos that currently use ${BRANCHOUT_GIT_BASEURL}"
+  fi
+
+  NEW_GIT_BASEURL="${1}"
+
+  if [ "${BRANCHOUT_GIT_BASEURL}" == "${NEW_GIT_BASEURL}" ]; then
+    fail "Old prefix and new prefix are the same, no point in continuing: ${BRANCHOUT_GIT_BASEURL}"
+  fi
+
+  echo "Relocating all Git repos from ${BRANCHOUT_GIT_BASEURL} to ${NEW_GIT_BASEURL}"
+  echo "in ${PROJECTION_DIRECTORY} and all nested repos 1 and 2 levels deep."
+
+  # Start with the entire git URL
+  OUR_FULL_URL="$(git --git-dir "${PROJECTION_DIRECTORY}/.git" remote get-url origin 2>/dev/null)"
+  echo "This is the current Git URL for ${PROJECTION_DIRECTORY}: ${OUR_FULL_URL}"
+
+  # Build our new URL
+  NEW_FULL_URL="${OUR_FULL_URL//${BRANCHOUT_GIT_BASEURL}/${NEW_GIT_BASEURL}}"
+  echo "This is the new Git URL for ${PROJECTION_DIRECTORY}: ${NEW_FULL_URL}"
+
+  echo "Validating the Git repo pointed at by the new URL above works..."
+  if git ls-remote "${NEW_FULL_URL}" > /dev/null; then
+    echo "New URL exists and you have access, proceeding..."
+  else
+    fail "New URL is bad, repo does not exist, or you have no access to it: ${NEW_FULL_URL}"
+  fi
+
+  # Collect together all of the Git config files to process
+  CONFIG_FILES=("${PROJECTION_DIRECTORY}/.git/config")
+
+  GROUP_CONFIG_FILE_PATTERN="${PROJECTION_DIRECTORY}/*/.git/config"
+  if compgen -G "${GROUP_CONFIG_FILE_PATTERN}" > /dev/null; then
+    mapfile -t GROUP_CONFIG_FILES < <(compgen -G "${GROUP_CONFIG_FILE_PATTERN}")
+    CONFIG_FILES=("${CONFIG_FILES[@]}" "${GROUP_CONFIG_FILES[@]}")
+    echo "Found ${#GROUP_CONFIG_FILES[@]} group .git/config files to process"
+  else
+    echo "No group .git/config files found to process."
+  fi
+
+  PROJECT_CONFIG_FILE_PATTERN="${PROJECTION_DIRECTORY}/*/*/.git/config"
+  if compgen -G "${PROJECT_CONFIG_FILE_PATTERN}" > /dev/null; then
+    mapfile -t PROJECT_CONFIG_FILES < <(compgen -G "${PROJECT_CONFIG_FILE_PATTERN}")
+    CONFIG_FILES=("${CONFIG_FILES[@]}" "${PROJECT_CONFIG_FILES[@]}")
+    echo "Found ${#PROJECT_CONFIG_FILES[@]} project .git/config files to process"
+  else
+    echo "No project .git/config files found to process."
+  fi
+
+  echo "Processing a total of ${#CONFIG_FILES[@]} .git/config files, including the base directory"
+
+  if [ "$(branchout_os)" == "mac" ]; then
+    echo "We're on a mac, do weird OSX-specific sed in-place replacement"
+    sed -i '' "s,${BRANCHOUT_GIT_BASEURL},${NEW_GIT_BASEURL}," "${CONFIG_FILES[@]}"
+  else
+    echo "We're not on a mac, do normal sed in-place replacement"
+    sed -i "s,${BRANCHOUT_GIT_BASEURL},${NEW_GIT_BASEURL}," "${CONFIG_FILES[@]}"
+  fi
+  echo "Relocation complete. To reverse what you just did, run 'branchout relocate ${BRANCHOUT_GIT_BASEURL}'"
+}
+
 function usage() {
   test -n "${1}" && echo "${1}" && echo
   echo "branchout: a tool for managing multi-repo projects
@@ -95,6 +158,8 @@ function usage() {
     pull <glob match>: pull all the matching projects and display their status, defaults to all
 
     clone <repository name>: add the repository to Branchoutprojects and clone it
+
+    relocate <new git clone URL base>: Repoint all matching remotes for all repos under the base dir to a new clone URL
 
     add: add a project to Branchoutprojects
 


### PR DESCRIPTION
…or even rewriting the URLs to provide security and isolation for multiple branchout roots using the same saas provider.

No tests, yet, so not ready to go, but you're welcome to review the change as is and give me any feedback you want to. 