### PR TITLE
Homebrew release antics improved

### DIFF
--- a/.deploy-to-homebrew
+++ b/.deploy-to-homebrew
@@ -113,4 +113,4 @@ userEmail="$(git config user.email)"
 userName="$(git config user.name)"
 
 # Then apply them to the freshly cloned repo
-(cd "$CHECKOUT_DIR" && git config user.email "${userEmail}" && git config user.name "${userName}" && git commit -a -m "$VERSION" && git tag -a -m"$VERSION" "$VERSION" && git push origin master --tags)
+(cd "$CHECKOUT_DIR" && git config user.email "${userEmail}" && git config user.name "${userName}" && git commit -a -m "$VERSION" && git tag -m "$VERSION" "$VERSION" HEAD && git push origin master --tags)

--- a/.deploy-to-homebrew
+++ b/.deploy-to-homebrew
@@ -113,4 +113,4 @@ userEmail="$(git config user.email)"
 userName="$(git config user.name)"
 
 # Then apply them to the freshly cloned repo
-(cd "$CHECKOUT_DIR" && git config user.email "${userEmail}" && git config user.name "${userName}" && git commit -a -m "$VERSION" && git tag -m "$VERSION" "$VERSION" HEAD && git push origin master --tags)
+(cd "$CHECKOUT_DIR" && git config user.email "${userEmail}" && git config user.name "${userName}" && git commit -a -m "$VERSION" && git tag -m "$VERSION" "$VERSION" HEAD && git push origin master "$VERSION")

--- a/.deploy-to-homebrew
+++ b/.deploy-to-homebrew
@@ -108,6 +108,10 @@ echo "class BranchoutYarn < Formula
 end
 " > "$CHECKOUT_DIR/branchout-yarn.rb"
 
+echo "Changes about to be committed:"
+git -C "$CHECKOUT_DIR" diff -U0
+read -p "Press enter to commit and push/publish the changes to homebrew, or ctrl C to cancel and bail out."
+
 # Read email/name from the main branchout repo that we're in when this script is run
 userEmail="$(git config user.email)"
 userName="$(git config user.name)"

--- a/.deploy-to-homebrew
+++ b/.deploy-to-homebrew
@@ -108,4 +108,9 @@ echo "class BranchoutYarn < Formula
 end
 " > "$CHECKOUT_DIR/branchout-yarn.rb"
 
-(cd "$CHECKOUT_DIR" && git config user.email "michael@stickycode.net" && git config user.name "Michael McCallum" && git commit -a -m "$VERSION" && git tag -a -m"$VERSION" "$VERSION" && git push origin master --tags)
+# Read email/name from the main branchout repo that we're in when this script is run
+userEmail="$(git config user.email)"
+userName="$(git config user.name)"
+
+# Then apply them to the freshly cloned repo
+(cd "$CHECKOUT_DIR" && git config user.email "${userEmail}" && git config user.name "${userName}" && git commit -a -m "$VERSION" && git tag -a -m"$VERSION" "$VERSION" && git push origin master --tags)

--- a/.deploy-to-homebrew
+++ b/.deploy-to-homebrew
@@ -31,7 +31,7 @@ echo "class Branchout < Formula
   depends_on \"branchout/branchout/branchout-yarn\"
 
   def install
-    bin.install "README.md"
+    bin.install "branchout-intro"
   end
 
   def test

--- a/branchout-intro
+++ b/branchout-intro
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo "Branchout is a fabulous tool for managing related sets of git repos in a clean and functional way."
+echo "It comes with a number of optional tool support modules: maven, node, yarn, and could do even more!"
+echo "For more info check out the git repo here: https://github.com/Branchout/branchout"
+echo "And if you're really keen, assist with homebrew packaging here: https://github.com/Branchout/homebrew-branchout"
+echo "Branchout is used in quite a few companies around the world and makes developer lives much easier."
+echo "Thanks for giving Branchout a try! We hope you like it :-)"


### PR DESCRIPTION
This should be good to go if you can't see any fatal issues and maybe disable your ssh key to test it or something? 

BUT it does NOT include a fix for the dependency on bad maven 3.8.2 - however hopefully it solves the bad homebrew packaging issues and makes the script a bit better and more portable. 

All feedback welcome, no glass houses here. 

See ongoing discussion on https://github.com/Homebrew/homebrew-core/pull/86188 for progress on getting a working Maven version in Brew - 3.5, 3,3, 3.2 are all too old/obsolete, 3.8.2 is broken for us, 3.8.1 is disallowed by policy, but getting a 3.6 in seems like it might be possible. Fingers crossed :-) 