### PR TITLE
Depend on our own tap's version of Maven, ie, 3.8.1

### DIFF
--- a/.deploy-to-homebrew
+++ b/.deploy-to-homebrew
@@ -75,7 +75,7 @@ echo "class BranchoutMaven < Formula
   version \"${VERSION:1}\"
 
   depends_on \"branchout/branchout/branchout-core\"
-  depends_on \"maven\"
+  depends_on \"branchout/branchout/maven@3.8.1\"
 
   def install
     bin.install \"branchout-maven\"


### PR DESCRIPTION
without the MINVOKER-283 bug that may or may not be fixed in 3.8.3 which isn't out yet. Requires PR on branchout homebrew tap repo to be merged before this is merged and the release containing it done: https://github.com/Branchout/homebrew-branchout/pull/4