### PR TITLE
shellcheck upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+BATS := $(shell which bats)
 export PATH := $(PWD)/bats/bin:$(PWD):$(PATH)
 VERSION := $(shell git describe --tags --abbrev=0)
 
@@ -14,28 +15,28 @@ repositories:
 	examples/make-repositories > target/repositories.log  2>&1
 
 test: clean canned repositories
-	bats --pretty bats
+	$(BATS) --pretty bats
 
 test-branchout: clean canned repositories
-	bats --pretty bats/branchout.bats
+	$(BATS) --pretty bats/branchout.bats
 
 test-branchout-maven: clean canned repositories
-	bats --pretty bats/branchout-maven.bats
+	$(BATS) --pretty bats/branchout-maven.bats
 
 test-branchout-yarn: clean canned repositories
-	bats --pretty bats/branchout-yarn.bats
+	$(BATS) --pretty bats/branchout-yarn.bats
 
 test-branchout-init: clean canned repositories
-	bats --pretty bats/branchout-init.bats
+	$(BATS) --pretty bats/branchout-init.bats
 
 test-group: clean canned repositories
-	bats --pretty bats/branchout-group.bats
+	$(BATS) --pretty bats/branchout-group.bats
 
 test-current: clean canned repositories
-	bats --pretty bats/current.bats
+	$(BATS) --pretty bats/current.bats
 
 travis: clean canned repositories
-	bats --tap bats
+	$(BATS) --tap bats
 
 deploy-to-homebrew:
 	VERSION=${VERSION} bash .deploy-to-homebrew

--- a/branchout
+++ b/branchout
@@ -195,7 +195,7 @@ function execute() {
     # shellcheck source=branchout-environment
     . "${BRANCHOUT_PATH}/branchout-environment"
 
-    eval branchout_"${branchoutModule}" "${@}"
+    branchout_"${branchoutModule}" "${@}"
 
   elif test -x "${BRANCHOUT_PATH}/branchout-${branchoutModule}"; then
     exec "${BRANCHOUT_PATH}/branchout-${branchoutModule}" "${@}"

--- a/branchout-group
+++ b/branchout-group
@@ -66,7 +66,7 @@ function branchoutGroupDerive() {
     echo "${1%%-*}"
 
   else
-    noPrefix="${1#${BRANCHOUT_PREFIX}-}"
+    noPrefix="${1#"${BRANCHOUT_PREFIX}"-}"
     echo "${noPrefix%%-*}"
   fi
 


### PR DESCRIPTION
- Somehow my shell/make is picking up the bats directory before /usr/bin/bats:
- Upgraded shellcheck caught these issues:
