### PR TITLE
Output should indicate if a pull results in an update

### DIFF
--- a/bats/branchout-projects.bats
+++ b/bats/branchout-projects.bats
@@ -58,6 +58,17 @@ frog-gemel"
   assert_success_file pull/fresh-clone-then-pull
 }
 
+@test "project clone then reset to previous commit then pull again" {
+  example fresh-clone-reset-then-pull
+  run branchout project pull frog-gemel
+  assert_success_file pull/fresh-clone
+  cd frog/frog-gemel
+  git reset --hard HEAD^1
+  cd ../..
+  run branchout project pull frog-gemel
+  assert_success_file pull/fresh-clone-reset-then-pull
+}
+
 @test "a project with conflicts" {
   example conflicts
   run branchout project pull frog-bet

--- a/branchout-project
+++ b/branchout-project
@@ -48,9 +48,18 @@ function projectUpdateError() {
 }
 
 function projectUpdate() {
+  local prePullHash
+  local postPullHash
+
   cd "${PROJECTION_DIRECTORY}/${projectContext}" || usage "Failed to enter project directory"
+  prePullHash=$(git rev-parse HEAD 2>/dev/null)
   if git pull --ff-only origin > /dev/null 2>&1; then
-    projectContextStatus "${projectName}" "Pulled  "
+    postPullHash=$(git rev-parse HEAD 2>/dev/null)
+    if test "${prePullHash}" = "${postPullHash}"; then
+      projectContextStatus "${projectName}" "Good    "
+    else
+      projectContextStatus "${projectName}" "Pulled  "
+    fi
   else
     projectUpdateError "${projectName}" "Failed  "
   fi

--- a/output/pull/fresh-clone-reset-then-pull.txt
+++ b/output/pull/fresh-clone-reset-then-pull.txt
@@ -1,0 +1,1 @@
+\033[0mPulled  frog/frog-gemel\033[70D\033[70Cmaster\033[0m

--- a/output/pull/fresh-clone-then-pull.txt
+++ b/output/pull/fresh-clone-then-pull.txt
@@ -1,1 +1,1 @@
-\033[0mPulled  frog/frog-gemel\033[70D\033[70Cmaster\033[0m
+\033[0mGood    frog/frog-gemel\033[70D\033[70Cmaster\033[0m

--- a/output/pull/lion-update.txt
+++ b/output/pull/lion-update.txt
@@ -1,2 +1,2 @@
 \033[0mNothing lion\033[70D\033[70C\033[35mNot a repository\033[0m
-\033[0mPulled  lion/lion-aleph\033[70D\033[70Cmaster\033[0m
+\033[0mGood    lion/lion-aleph\033[70D\033[70Cmaster\033[0m

--- a/output/pull/rabbit-update.txt
+++ b/output/pull/rabbit-update.txt
@@ -1,2 +1,2 @@
 \033[0mPulled  rabbit\033[70D\033[70Cmaster\033[0m
-\033[0mPulled  rabbit/rabbit-aleph\033[70D\033[70Cmaster\033[0m
+\033[0mGood    rabbit/rabbit-aleph\033[70D\033[70Cmaster\033[0m


### PR DESCRIPTION
It would be nice if the output to `branchout pull` indicated whether a repo was updated or already up-to-date.

Currently the same output is shown for both cases, i.e.:

```
Pulled  rabbit/rabbit-aleph         master
```
------
This PR changes the output to indicate when a repo is up-to-date:

**Updated:**
```
Pulled  rabbit/rabbit-aleph         master
```

**Up to date:**
```
Good    rabbit/rabbit-aleph         master
```